### PR TITLE
Support for Grails 1.3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'com.connorgarvey.gradle'
-version = '1.0'
+version = '1.0.1'
 description = 'A plugin for Gradle to build Grails projects'
 
 repositories {

--- a/src/main/groovy/com/connorgarvey/gradlegrails/GrailsPlugin.groovy
+++ b/src/main/groovy/com/connorgarvey/gradlegrails/GrailsPlugin.groovy
@@ -21,11 +21,12 @@ class GrailsPlugin implements Plugin<Project> {
       project.grails.configure()
       String grailsFolder = makeGrailsPath(project.grails.version)
       String extension = SystemUtils.IS_OS_WINDOWS ? '.bat' : ''
+      String plainOutput = project.grails.version.startsWith('1.3.') ? '' : '-plain-output'
       List<String> args = collectArguments(project)
       List<String> systemProperties = collectSystemProperties(project)
       List<String> command = [
         Path.join(grailsFolder, 'bin', "grails${extension}"),
-        '-plain-output'
+        plainOutput
       ]
       command.addAll(systemProperties.collect { "-D${it}" })
       command.add(target)
@@ -131,7 +132,8 @@ class GrailsPlugin implements Plugin<Project> {
   private void build(Project project, String target) {
     String grailsFolder = makeGrailsPath(project.grails.version)
     String extension = SystemUtils.IS_OS_WINDOWS ? '.bat' : ''
-    Process process = "${Path.join(grailsFolder, 'bin', 'grails' + extension)} -plain-output ${target}".execute()
+    String plainOutput = project.grails.version.startsWith('1.3.') ? '' : '-plain-output'
+    Process process = "${Path.join(grailsFolder, 'bin', 'grails' + extension)} ${plainOutput} ${target}".execute()
     String s = null
     StringBuilder output = new StringBuilder()
     BufferedReader input = new BufferedReader(new InputStreamReader(process.inputStream))


### PR DESCRIPTION
Grails 1.3.7 doesn't understand the '-plain-output' arg passed in to the grails command.  This change selectively ommits this argument if grails version is part of the 1.3.X versions.
